### PR TITLE
feat: add alphabetical client report

### DIFF
--- a/app/Http/Controllers/ClienteController.php
+++ b/app/Http/Controllers/ClienteController.php
@@ -28,4 +28,11 @@ class ClienteController extends Controller
 
         return view('clientes', compact('clientes'));
     }
+
+    public function relatorioClientes()
+    {
+        $clientes = Cliente::orderBy('nome')->get();
+
+        return view('relatorios.clientes', compact('clientes'));
+    }
 }

--- a/resources/views/relatorios.blade.php
+++ b/resources/views/relatorios.blade.php
@@ -41,4 +41,13 @@
             </div>
         </div>
     </div>
+    <div class="py-2">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900" style="font-size:1pc;">
+                    <h3><a href="{{ route('relatorios.clientes') }}">Clientes</a></h3>
+                </div>
+            </div>
+        </div>
+    </div>
 </x-app-layout>

--- a/resources/views/relatorios/clientes.blade.php
+++ b/resources/views/relatorios/clientes.blade.php
@@ -1,0 +1,42 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Relatório de Clientes') }}
+        </h2>
+    </x-slot>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    @if ($clientes->count())
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">CPF</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Telefone</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Aniversário</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Observação</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach ($clientes as $cliente)
+                            <tr>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->nome }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->cpf }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->telefone }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->aniversario }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->observacao }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                    @else
+                    <p>Nenhum(a) cliente cadastrado(a).</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,9 +28,9 @@ Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
-Route::get('/estoque', [ProdutoController::class, 'estoque'], function () {
-    return view('estoque');
-})->middleware(['auth', 'verified'])->name('estoque');
+Route::get('/estoque', [ProdutoController::class, 'estoque'])
+    ->middleware(['auth', 'verified'])
+    ->name('estoque');
 
 // Rota para abrir edição do produto
 Route::get('/cadastro/{produto}/editar', [ProdutoController::class, 'edit'])->name('produto.edit');
@@ -40,34 +40,34 @@ Route::put('/cadastro/{produto}', [ProdutoController::class, 'update'])->name('p
 
 
 // Rota para a página de cadastro
-Route::get('/cadastro',  [ProdutoController::class, 'createProduto' ], function () {
-    return view('cadastro');
-})->middleware(['auth', 'verified'])->name('cadastro');
+Route::get('/cadastro', [ProdutoController::class, 'createProduto'])
+    ->middleware(['auth', 'verified'])
+    ->name('cadastro');
 
 // Rota para salvar o produto
 Route::post('/cadastro', [ProdutoController::class, 'store'])->name('produto.store');
 
 
-Route::get('/vendas', [VendaController::class, 'clientProductList'], function () {
-    return view('vendas');
-})->middleware(['auth', 'verified'])->name('vendas');
+Route::get('/vendas', [VendaController::class, 'clientProductList'])
+    ->middleware(['auth', 'verified'])
+    ->name('vendas');
 
 // Rota para salvar a venda
 Route::post('/vendas', [VendaController::class, 'sale'])->name('venda.sale');
 
 // Rota para a página de clientes
-Route::get('/clientes', [ClienteController::class, 'listaCliente'], function () {
-    return view('clientes');
-})->middleware(['auth', 'verified'])->name('clientes');
+Route::get('/clientes', [ClienteController::class, 'listaCliente'])
+    ->middleware(['auth', 'verified'])
+    ->name('clientes');
 
 // Rota para salvar o cliente
 Route::post('/clientes', [ClienteController::class, 'clients'])->name('cliente.clients');
 
 
 // Rota para a página de fornecedores
-Route::get('/fornecedores', [FornecedorController::class, 'listaFornecedor'], function () {
-    return view('fornecedores');
-})->middleware(['auth', 'verified'])->name('fornecedores');
+Route::get('/fornecedores', [FornecedorController::class, 'listaFornecedor'])
+    ->middleware(['auth', 'verified'])
+    ->name('fornecedores');
 
 // Rota para salvar o fornecedor
 Route::post('/fornecedores', [FornecedorController::class, 'criaFornecedor'])->name('fornecedor.criaFornecedor');
@@ -76,9 +76,9 @@ Route::post('/fornecedores', [FornecedorController::class, 'criaFornecedor'])->n
 //     return view('contasReceber');
 // })->middleware(['auth', 'verified'])->name('contasReceber');
 
-Route::get('/entradas', [EntradaController::class, 'FornecedorProductList'], function () {
-    return view('entradas');
-})->middleware(['auth', 'verified'])->name('entradas');
+Route::get('/entradas', [EntradaController::class, 'FornecedorProductList'])
+    ->middleware(['auth', 'verified'])
+    ->name('entradas');
 
 // Rota para salvar a entrada
 Route::post('/entradas', [EntradaController::class, 'entry'])->name('entrada.entry');
@@ -106,6 +106,10 @@ Route::post('/company/save', [CompanyController::class, 'save'])->name('company.
 Route::get('/relatorios', function () {
     return view('relatorios');
 })->middleware(['auth', 'verified'])->name('relatorios');
+
+Route::get('/relatorios/clientes', [ClienteController::class, 'relatorioClientes'])
+    ->middleware(['auth', 'verified'])
+    ->name('relatorios.clientes');
 
 
 // Rotas de edição e autenticação de usuário


### PR DESCRIPTION
## Summary
- remove extraneous closures from route definitions causing argument errors
- add client report listing all customers alphabetically

## Testing
- `composer install` *(fails: nette/schema v1.2.4 requires php 7.1 - 8.3)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68939e3e5c248324bd4d2947bfdb8f32