### PR TITLE
Add PDF and Excel export for client reports

### DIFF
--- a/app/Exports/ClientesExport.php
+++ b/app/Exports/ClientesExport.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\Cliente;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+class ClientesExport implements FromCollection, WithHeadings
+{
+    public function collection()
+    {
+        return Cliente::orderBy('nome')
+            ->get(['nome', 'cpf', 'telefone', 'aniversario', 'observacao']);
+    }
+
+    public function headings(): array
+    {
+        return ['Nome', 'CPF', 'Telefone', 'Aniversário', 'Observação'];
+    }
+}
+

--- a/app/Http/Controllers/ClienteController.php
+++ b/app/Http/Controllers/ClienteController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Cliente;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Maatwebsite\Excel\Facades\Excel;
+use App\Exports\ClientesExport;
 
 class ClienteController extends Controller
 {
@@ -34,5 +37,17 @@ class ClienteController extends Controller
         $clientes = Cliente::orderBy('nome')->get();
 
         return view('relatorios.clientes', compact('clientes'));
+    }
+
+    public function exportClientesPdf()
+    {
+        $clientes = Cliente::orderBy('nome')->get();
+        $pdf = Pdf::loadView('relatorios.clientes', compact('clientes'));
+        return $pdf->download('relatorio_clientes.pdf');
+    }
+
+    public function exportClientesExcel()
+    {
+        return Excel::download(new ClientesExport, 'relatorio_clientes.xlsx');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
         "laravel/breeze": "1.24",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.2",
-        "laravel/tinker": "^2.8"
+        "laravel/tinker": "^2.8",
+        "barryvdh/laravel-dompdf": "^2.0",
+        "maatwebsite/excel": "^3.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/resources/views/relatorios.blade.php
+++ b/resources/views/relatorios.blade.php
@@ -45,7 +45,11 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900" style="font-size:1pc;">
-                    <h3><a href="{{ route('relatorios.clientes') }}">Clientes</a></h3>
+                    <h3 class="flex items-center">
+                        <a href="{{ route('relatorios.clientes') }}" class="flex-1">Clientes</a>
+                        <a href="{{ route('relatorios.clientes.pdf') }}" class="ml-2" title="Exportar PDF">📄</a>
+                        <a href="{{ route('relatorios.clientes.excel') }}" class="ml-2" title="Exportar Excel">📊</a>
+                    </h3>
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -111,6 +111,14 @@ Route::get('/relatorios/clientes', [ClienteController::class, 'relatorioClientes
     ->middleware(['auth', 'verified'])
     ->name('relatorios.clientes');
 
+Route::get('/relatorios/clientes/pdf', [ClienteController::class, 'exportClientesPdf'])
+    ->middleware(['auth', 'verified'])
+    ->name('relatorios.clientes.pdf');
+
+Route::get('/relatorios/clientes/excel', [ClienteController::class, 'exportClientesExcel'])
+    ->middleware(['auth', 'verified'])
+    ->name('relatorios.clientes.excel');
+
 
 // Rotas de edição e autenticação de usuário
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
## Summary
- add PDF and Excel export options for the client report
- expose export routes and controller methods
- show export icons next to Clientes report link

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/estoque-app/vendor/autoload.php')*
- `composer install` *(fails: nette/schema v1.2.4 requires php 7.1 - 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b83e2b4fb0832487c1e16836f2c8ba