### PR TITLE
Register DomPDF service provider for PDF export

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,7 @@
 <?php
 
+use Barryvdh\DomPDF\Facade\Pdf as PdfFacade;
+use Barryvdh\DomPDF\ServiceProvider as DomPDFServiceProvider;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 
@@ -160,6 +162,8 @@ return [
          * Package Service Providers...
          */
 
+        DomPDFServiceProvider::class,
+
         /*
          * Application Service Providers...
          */
@@ -183,6 +187,7 @@ return [
 
     'aliases' => Facade::defaultAliases()->merge([
         // 'Example' => App\Facades\Example::class,
+        'Pdf' => PdfFacade::class,
     ])->toArray(),
 
 ];


### PR DESCRIPTION
## Summary
- register DomPDF service provider and alias to enable PDF export

## Testing
- `composer install` *(fails: nette/schema v1.2.4 requires php 7.1 - 8.3)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b849bdc6ac8324b53d163e2fa0469c