### PR TITLE
Ajustar layout do relatório de clientes em PDF

### DIFF
--- a/app/Http/Controllers/ClienteController.php
+++ b/app/Http/Controllers/ClienteController.php
@@ -44,7 +44,7 @@ class ClienteController extends Controller
     public function exportClientesPdf()
     {
         $clientes = Cliente::orderBy('nome')->get();
-        $pdf = Pdf::loadView('relatorios.clientes', compact('clientes'));
+        $pdf = Pdf::loadView('relatorios.clientes_pdf', compact('clientes'));
         return $pdf->download('relatorio_clientes.pdf');
     }
 

--- a/resources/views/relatorios/clientes.blade.php
+++ b/resources/views/relatorios/clientes.blade.php
@@ -14,8 +14,9 @@
                             <tr>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">CPF</th>
-                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Telefone</th>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Aniversário</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Telefone</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Observação</th>
                             </tr>
                         </thead>
@@ -24,8 +25,9 @@
                             <tr>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->nome }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->cpf }}</td>
-                                <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->telefone }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->aniversario }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->telefone }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->email }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $cliente->observacao }}</td>
                             </tr>
                             @endforeach

--- a/resources/views/relatorios/clientes_pdf.blade.php
+++ b/resources/views/relatorios/clientes_pdf.blade.php
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            font-size: 12px;
+        }
+        h1 {
+            text-align: center;
+            font-size: 20px;
+            margin-bottom: 20px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            border: 1px solid #d1d5db;
+            padding: 8px;
+            font-size: 12px;
+        }
+        th {
+            background-color: #f3f4f6;
+            text-align: left;
+        }
+    </style>
+</head>
+<body>
+    <h1>RELATÓRIO DE CLIENTES</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Nome</th>
+                <th>CPF</th>
+                <th>Aniversário</th>
+                <th>Telefone</th>
+                <th>Email</th>
+                <th>Observação</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($clientes as $cliente)
+            <tr>
+                <td>{{ $cliente->nome }}</td>
+                <td>{{ $cliente->cpf }}</td>
+                <td>{{ $cliente->aniversario }}</td>
+                <td>{{ $cliente->telefone }}</td>
+                <td>{{ $cliente->email }}</td>
+                <td>{{ $cliente->observacao }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- exibir email e aniversários no relatório HTML
- gerar PDF de clientes com tabela estilizada

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b85cd417248324b523b9fdd1107d5d