### PR TITLE
Add Excel provider and alias

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -163,6 +163,7 @@ return [
          */
 
         DomPDFServiceProvider::class,
+        Maatwebsite\Excel\ExcelServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -188,6 +189,7 @@ return [
     'aliases' => Facade::defaultAliases()->merge([
         // 'Example' => App\Facades\Example::class,
         'Pdf' => PdfFacade::class,
+        'Excel' => Maatwebsite\Excel\Facades\Excel::class,
     ])->toArray(),
 
 ];


### PR DESCRIPTION
## Summary
- register Maatwebsite Excel service provider for spreadsheet exports
- expose Excel facade for convenient usage

## Testing
- `php artisan config:clear` *(fails: Failed opening required '/workspace/estoque-app/vendor/autoload.php')*
- `php artisan cache:clear` *(fails: Failed opening required '/workspace/estoque-app/vendor/autoload.php')*
- `php artisan tinker --execute="app(App\\Http\\Controllers\\ClienteController::class)->exportClientesExcel();"` *(fails: Failed opening required '/workspace/estoque-app/vendor/autoload.php')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68b86316fe04832495ae5dbf8482a326